### PR TITLE
Add spice proxy support to engine

### DIFF
--- a/3.6/entrypoint.sh
+++ b/3.6/entrypoint.sh
@@ -18,6 +18,10 @@ cp -a /etc/pki/ovirt-engine.tmpl/* /etc/pki/ovirt-engine/
 
 engine-setup --config=answers.conf --offline
 
+if [ -n "$SPICE_PROXY" ]
+  engine-config -s SpiceProxyDefault=$SPICE_PROXY
+fi
+
 export PGPASSWORD=$POSTGRES_PASSWORD
 psql $POSTGRES_DB -h $POSTGRES_HOST -p $POSTGRES_PORT  -U $POSTGRES_USER -c "UPDATE vdc_options set option_value = '$HOST_ENCRYPT' WHERE option_name = 'SSLEnabled';"
 psql $POSTGRES_DB -h $POSTGRES_HOST -p $POSTGRES_PORT  -U $POSTGRES_USER -c "UPDATE vdc_options set option_value = '$HOST_ENCRYPT' WHERE option_name = 'EncryptHostCommunication';"

--- a/3.6/ovirt-engine-pod.json
+++ b/3.6/ovirt-engine-pod.json
@@ -69,6 +69,10 @@
           {
             "name": "OVIRT_PKI_ORGANIZATION",
             "value": "oVirt"
+          },
+          {
+            "name": "SPICE_PROXY",
+            "value": "http://YOUR_IP_HERE:3128"
           }
         ]
       },
@@ -104,13 +108,14 @@
         ]
       },
       {
-        "name": "kubectl",
-        "image": "gcr.io/google_containers/kubectl:v0.18.0-120-gaeb4ac55ad12b1-dirty",
+        "name": "spice-proxy",
+        "image": "rmohr/spice-squid",
         "imagePullPolicy": "Always",
-        "args": [
-          "proxy",
-          "-p",
-          "8001"
+        "ports": [
+          {
+            "containerPort": 3128,
+            "name": "engine-spice-proxy"
+          }
         ]
       }
     ],

--- a/3.6/ovirt-engine-service.json
+++ b/3.6/ovirt-engine-service.json
@@ -20,6 +20,12 @@
         "protocol": "TCP",
         "port": 443,
         "targetPort": "engine-tls"
+      },
+      {
+        "name": "engine-spice-proxy",
+        "protocol": "TCP",
+        "port": 3128,
+        "targetPort": "engine-spice-proxy"
       }
     ],
     "externalIPs": [

--- a/4.0/ovirt-engine-pod.json
+++ b/4.0/ovirt-engine-pod.json
@@ -69,6 +69,10 @@
           {
             "name": "OVIRT_PKI_ORGANIZATION",
             "value": "oVirt"
+          },
+          {
+            "name": "SPICE_PROXY",
+            "value": "http://YOUR_IP_HERE:3128"
           }
         ]
       },
@@ -104,13 +108,14 @@
         ]
       },
       {
-        "name": "kubectl",
-        "image": "gcr.io/google_containers/kubectl:v0.18.0-120-gaeb4ac55ad12b1-dirty",
+        "name": "spice-proxy",
+        "image": "rmohr/spice-squid",
         "imagePullPolicy": "Always",
-        "args": [
-          "proxy",
-          "-p",
-          "8001"
+        "ports": [
+          {
+            "containerPort": 3128,
+            "name": "engine-spice-proxy"
+          }
         ]
       }
     ],

--- a/4.0/ovirt-engine-service.json
+++ b/4.0/ovirt-engine-service.json
@@ -20,6 +20,12 @@
         "protocol": "TCP",
         "port": 443,
         "targetPort": "engine-tls"
+      },
+      {
+        "name": "engine-spice-proxy",
+        "protocol": "TCP",
+        "port": 3128,
+        "targetPort": "engine-spice-proxy"
       }
     ],
     "externalIPs": [


### PR DESCRIPTION
It is now possible to set a spice proxy via the `$SPICE_PROXY`
environment variable. Further the example kubernetes Pod and Service
definitions include a squid proxy for spice.
