### PR TITLE
Make host identifier usage configurable

### DIFF
--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -51,5 +51,8 @@ VOLUME /var/lib/ovirt-engine/backups
 ENV HOST_ENCRYPT=true
 # Try to provision hosts when they are added
 ENV HOST_INSTALL=true
+# Use host identifier when talking with the host, so that the host sees who it is from the engines view.
+# This is valuable when working with ovirt-vdsmfake
+ENV HOST_USE_IDENTIFIER=false
 
 CMD bash /entrypoint.sh

--- a/3.6/entrypoint.sh
+++ b/3.6/entrypoint.sh
@@ -25,6 +25,7 @@ fi
 export PGPASSWORD=$POSTGRES_PASSWORD
 psql $POSTGRES_DB -h $POSTGRES_HOST -p $POSTGRES_PORT  -U $POSTGRES_USER -c "UPDATE vdc_options set option_value = '$HOST_ENCRYPT' WHERE option_name = 'SSLEnabled';"
 psql $POSTGRES_DB -h $POSTGRES_HOST -p $POSTGRES_PORT  -U $POSTGRES_USER -c "UPDATE vdc_options set option_value = '$HOST_ENCRYPT' WHERE option_name = 'EncryptHostCommunication';"
-psql $POSTGRES_DB -h $POSTGRES_HOST -p $POSTGRES_PORT  -U $POSTGRES_USER -c "UPDATE vdc_options set option_value = '$HOST_INSTALL' where option_name = 'InstallVds'"
+psql $POSTGRES_DB -h $POSTGRES_HOST -p $POSTGRES_PORT  -U $POSTGRES_USER -c "UPDATE vdc_options set option_value = '$HOST_INSTALL' where option_name = 'InstallVds';"
+psql $POSTGRES_DB -h $POSTGRES_HOST -p $POSTGRES_PORT  -U $POSTGRES_USER -c "UPDATE vdc_options set option_value = '$HOST_USE_IDENTIFIER' WHERE option_name = 'UseHostNameIdentifier';"
 
 su -m -s /bin/python ovirt /usr/share/ovirt-engine/services/ovirt-engine/ovirt-engine.py start

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -51,5 +51,8 @@ VOLUME /var/lib/ovirt-engine/backups
 ENV HOST_ENCRYPT=true
 # Try to provision hosts when they are added
 ENV HOST_INSTALL=true
+# Use host identifier when talking with the host, so that the host sees who it is from the engines view.
+# This is valuable when working with ovirt-vdsmfake
+ENV HOST_USE_IDENTIFIER=false
 
 CMD bash /entrypoint.sh

--- a/4.0/entrypoint.sh
+++ b/4.0/entrypoint.sh
@@ -25,6 +25,7 @@ fi
 export PGPASSWORD=$POSTGRES_PASSWORD
 psql $POSTGRES_DB -h $POSTGRES_HOST -p $POSTGRES_PORT  -U $POSTGRES_USER -c "UPDATE vdc_options set option_value = '$HOST_ENCRYPT' WHERE option_name = 'SSLEnabled';"
 psql $POSTGRES_DB -h $POSTGRES_HOST -p $POSTGRES_PORT  -U $POSTGRES_USER -c "UPDATE vdc_options set option_value = '$HOST_ENCRYPT' WHERE option_name = 'EncryptHostCommunication';"
-psql $POSTGRES_DB -h $POSTGRES_HOST -p $POSTGRES_PORT  -U $POSTGRES_USER -c "UPDATE vdc_options set option_value = '$HOST_INSTALL' where option_name = 'InstallVds'"
+psql $POSTGRES_DB -h $POSTGRES_HOST -p $POSTGRES_PORT  -U $POSTGRES_USER -c "UPDATE vdc_options set option_value = '$HOST_INSTALL' where option_name = 'InstallVds';"
+psql $POSTGRES_DB -h $POSTGRES_HOST -p $POSTGRES_PORT  -U $POSTGRES_USER -c "UPDATE vdc_options set option_value = '$HOST_USE_IDENTIFIER' WHERE option_name = 'UseHostNameIdentifier';"
 
 su -m -s /bin/python ovirt /usr/share/ovirt-engine/services/ovirt-engine/ovirt-engine.py start


### PR DESCRIPTION
When working with ovirt-vdsmfake, vdsmfake can only report the right
values when it knows which server it is in the eyes of ovirt-engine. By
settint `HOST_USE_IDENTIFIER` tho 'true', vdsmfake will get this
information from the engine.