### PR TITLE
Config BlockMigrationOnSwapUsagePercentage to high value

### DIFF
--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -59,6 +59,9 @@ ENV HOST_INSTALL=true
 # Use host identifier when talking with the host, so that the host sees who it is from the engines view.
 # This is valuable when working with ovirt-vdsmfake
 ENV HOST_USE_IDENTIFIER=false
+# HACK: Config BlockMigrationOnSwapUsagePercentage so that the vm will start in ovirt-engine
+# For some reason this check fails the start vm - this should be figured out instead of this hack
+ENV BLOCK_MIGRATION_ON_SWAP_USAGE_PERCENTAGE=9999
 
 # Public reachable HTTPS port
 ENV HTTPS_PORT 8443

--- a/4.0/entrypoint.sh
+++ b/4.0/entrypoint.sh
@@ -47,4 +47,6 @@ psql $POSTGRES_DB -h $POSTGRES_HOST -p $POSTGRES_PORT  -U $POSTGRES_USER -c "UPD
 psql $POSTGRES_DB -h $POSTGRES_HOST -p $POSTGRES_PORT  -U $POSTGRES_USER -c "UPDATE vdc_options set option_value = '$HOST_INSTALL' where option_name = 'InstallVds';"
 psql $POSTGRES_DB -h $POSTGRES_HOST -p $POSTGRES_PORT  -U $POSTGRES_USER -c "UPDATE vdc_options set option_value = '$HOST_USE_IDENTIFIER' WHERE option_name = 'UseHostNameIdentifier';"
 
+engine-config -s BlockMigrationOnSwapUsagePercentage='$ENV BLOCK_MIGRATION_ON_SWAP_USAGE_PERCENTAGE'
+
 su -m -s /bin/python ovirt /usr/share/ovirt-engine/services/ovirt-engine/ovirt-engine.py start


### PR DESCRIPTION
Engine check the following:
if (swap_total - swap_free - mem_available) * 100 / physical_mem_mb) <= \
        BlockMigrationOnSwapUsagePercentage

  fail the vm start with "Host '{}' swap value is illegal"

To avoid changing the swap memory size, this config prevent this failure

Signed-off-by: Yaniv Bronhaim <ybronhei@redhat.com>